### PR TITLE
updated mws.py replacing e.message with str(e) on line 170

### DIFF
--- a/mws/mws.py
+++ b/mws/mws.py
@@ -167,7 +167,7 @@ class MWS(object):
                 parsed_response = DataWrapper(data, response.headers)
 
         except HTTPError, e:
-            error = MWSError(e.message)
+            error = MWSError(str(e))
             error.response = getattr(e, 'response')
             raise error
 


### PR DESCRIPTION
Fixing deprecation warning: DeprecationWarning: BaseException.message has been deprecated as of Python 2.6
