### PR TITLE
Added auth_token to mws

### DIFF
--- a/mws/mws.py
+++ b/mws/mws.py
@@ -141,10 +141,11 @@ class MWS(object):
     # Which is the name of the parameter for that specific account type.
     ACCOUNT_TYPE = "SellerId"
 
-    def __init__(self, access_key, secret_key, account_id, region='US', domain='', uri="", version=""):
+    def __init__(self, access_key, secret_key, account_id, region='US', domain='', uri="", version="", auth_token=""):
         self.access_key = access_key
         self.secret_key = secret_key
         self.account_id = account_id
+        self.auth_token = auth_token
         self.version = version or self.VERSION
         self.uri = uri or self.URI
 
@@ -175,6 +176,8 @@ class MWS(object):
             'Version': self.version,
             'SignatureMethod': 'HmacSHA256',
         }
+        if self.auth_token:
+            params['MWSAuthToken'] = self.auth_token                    
         params.update(extra_data)
         request_description = '&'.join(['%s=%s' % (k, urllib.quote(params[k], safe='-_.~').encode('utf-8')) for k in sorted(params)])
         signature = self.calc_signature(method, request_description)


### PR DESCRIPTION
Added auth_token to mws **init**. auth_token will be used on all
requests to amazon. Added to the end of the parameter list for backwards
compatibility.

Added to the params dict only if given due to the comment that MWS 
doesn't like empty values.

Starting Aug 19, 2014 AMS asks for a MWSAuthToken parameter for all
requests from 3rd parties.  This is optional for 3rd parties until March
31, 2015, when it will be required.  More information can be found here:

http://docs.developer.amazonservices.com/en_US/auth_token/index.html
