### PR TITLE
GetLowestPricedOffersFor* Product APIs

### DIFF
--- a/mws/mws.py
+++ b/mws/mws.py
@@ -510,6 +510,22 @@ class Products(MWS):
         data.update(self.enumerate_param('ASINList.ASIN.', asins))
         return self.make_request(data)
 
+    def get_lowest_priced_offers_for_sku(self, marketplaceid, sku, condition="New", excludeme="False"):
+        data = dict(Action='GetLowestPricedOffersForSKU',
+                    MarketplaceId=marketplaceid,
+                    SellerSKU=sku,
+                    ItemCondition=condition,
+                    ExcludeMe=excludeme)
+        return self.make_request(data)
+
+    def get_lowest_priced_offers_for_asin(self, marketplaceid, asin, condition="New", excludeme="False"):
+        data = dict(Action='GetLowestPricedOffersForASIN',
+                    MarketplaceId=marketplaceid,
+                    ASIN=asin,
+                    ItemCondition=condition,
+                    ExcludeMe=excludeme)
+        return self.make_request(data)
+
     def get_product_categories_for_sku(self, marketplaceid, sku):
         data = dict(Action='GetProductCategoriesForSKU',
                     MarketplaceId=marketplaceid,


### PR DESCRIPTION
Implementation of the missing methods to query the `GetLowestPricedOffersForSKU` and `GetLowestPricedOffersForASIN` Product APIs (see http://docs.developer.amazonservices.com/en_US/products/Products_GetLowestPricedOffersForSKU.html and http://docs.developer.amazonservices.com/en_US/products/Products_GetLowestPricedOffersForASIN.html, respectively).